### PR TITLE
Update cifar10_dvs.py

### DIFF
--- a/events_tfds/events/cifar10_dvs.py
+++ b/events_tfds/events/cifar10_dvs.py
@@ -104,6 +104,8 @@ class Cifar10DVS(tfds.core.GeneratorBasedBuilder):
                 example_id = int(filename.split('_')[-1][:-6])
                 with open(path, 'rb') as fp:
                     time, x, y, polarity = dvs.load_events(fp)
+                    x = 127 - x
+                    polarity = np.logical_not(polarity)
                 coords = np.stack((x, y), axis=-1)
                 features = dict(events=dict(time=time.astype(np.int64),
                                             coords=coords.astype(np.int64),


### PR DESCRIPTION
I find that the event data read by cifar10_dvs.py have a little difference with that read by MATLAB (http://www2.imse-cnm.csic.es/caviar/MNIST_DVS/dat2mat.m).
Hence, I make some change to make them output the same results (in MATLAB polarity is -1 or +1, I use False as -1 and True as +1):
 x = 127 - x
 polarity = np.logical_not(polarity)